### PR TITLE
Put the version hackery back

### DIFF
--- a/nix/tahoe-lafs.nix
+++ b/nix/tahoe-lafs.nix
@@ -1,20 +1,22 @@
 { python2Packages }:
 let
-  # Manually assemble the tahoe-lafs build inputs because tahoe-lafs 1.14.0
-  # eliot package runs the eliot test suite which is flaky.  Doing this gives
-  # us a place to insert a `doCheck = false` (at the cost of essentially
-  # duplicating tahoe-lafs' default.nix).  Not ideal but at least we can throw
-  # it away when we upgrade to the next tahoe-lafs version.
   repo = ((import ./tahoe-lafs-repo.nix) + "/nix");
-  nevow-drv = repo + "/nevow.nix";
-  nevow = python2Packages.callPackage nevow-drv { };
-  eliot-drv = repo + "/eliot.nix";
-  eliot = (python2Packages.callPackage eliot-drv { }).overrideAttrs (old: {
-    doInstallCheck = false;
+  tahoe-lafs-drv = repo + "/default.nix";
+  tahoe-lafs = python2Packages.callPackage tahoe-lafs-drv { };
+  versioned-tahoe-lafs = tahoe-lafs.overrideAttrs (old: rec {
+    # Upstream is versioned as 1.14.0.dev, still, even though it is now
+    # 1.15.1.
+    version = "1.15.1";
+    name = "tahoe-lafs-1.15.1";
+    postPatch = ''
+      ${old.postPatch}
+
+      # We got rid of our .git directory so the built-in version computing logic
+      # won't work.  The exact strings we emit here matter because of custom
+      # parsing Tahoe-LAFS applies.
+      echo 'verstr = "${version}"' > src/allmydata/_version.py
+      echo '__version__ = verstr' >> src/allmydata/_version.py
+    '';
   });
-  tahoe-lafs-drv = repo + "/tahoe-lafs.nix";
-  tahoe-lafs = python2Packages.callPackage tahoe-lafs-drv {
-    inherit nevow eliot;
-  };
 in
-  tahoe-lafs
+  versioned-tahoe-lafs


### PR DESCRIPTION
However, we get to stop passing some overidden packages because at least Tahoe 1.15.1 handles those better now.